### PR TITLE
Retry S3 request when getting 301 without location

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -56,7 +56,17 @@ s3simple() {
   local signature=$(echo -n "$string_to_sign" | openssl sha1 -binary -hmac "${AWS_SECRET_ACCESS_KEY}" | openssl base64)
   local authorization="AWS ${AWS_ACCESS_KEY_ID}:${signature}"
 
-  curl -o s3-tarball-buildpack-temp.tgz --fail --silent --show-error $args -H Date:"${date}" -H Authorization:"${authorization}" https://s3.amazonaws.com"${path}"
+  local response=`curl -w '%{http_code}' -o s3-tarball-buildpack-temp.tgz --fail --silent --show-error $args -H Date:"${date}" -H Authorization:"${authorization}" https://s3.amazonaws.com"${path}"`
+  if [ $response == 301 ]; then
+    path=${path#*/}
+    local bucket=${path%%/*}
+    path=${path#*/}
+    response=`curl -w '%{http_code}' -o s3-tarball-buildpack-temp.tgz --fail --silent --show-error $args -H Date:"${date}" -H Authorization:"${authorization}" "https://$bucket.s3.amazonaws.com/$path"`
+  fi
+
+  if [ $response != 200 ]; then
+    error "AWS S3 response code was $response"
+  fi
   tar -xvzf s3-tarball-buildpack-temp.tgz
   rm -f s3-tarball-buildpack-temp-tgz
 }


### PR DESCRIPTION
This PR aims to address issue where instead of a 200 response, `S3` will send a 301 without location headers and a XML response pointing to a different endpoint and this ends up being confused with a valid `tgz` archive and fails in the next step.

Fixes #3 